### PR TITLE
Fix radiotap padding

### DIFF
--- a/src/libwifi/gen/misc/radiotap.c
+++ b/src/libwifi/gen/misc/radiotap.c
@@ -36,6 +36,11 @@ size_t libwifi_create_radiotap(struct libwifi_radiotap_info *info, char *radiota
     uint32_t presence_bit = rtap_hdr.it_present;
     for (int field = 0; field < radiotap_ns.n_bits; field++) {
         if (presence_bit & 1) {
+            uint8_t padding = offset % radiotap_ns.align_size[field].align;
+            if (padding > 0) {
+                memset(rtap_data + offset, 0, padding);
+                offset += padding;
+            }
             switch (field) {
                 case IEEE80211_RADIOTAP_CHANNEL:
                     memcpy(rtap_data + offset, &info->channel.freq, sizeof(info->channel.freq));


### PR DESCRIPTION
According to the section "Alignment in Radiotap" on the [radiotap](https://www.radiotap.org/) website, the radiotap header fields must be padded. 8-bit fields must be 8-bit aligned, 16-bit must be 16-bit aligned, etc. In the current implementation, `libwifi_create_radiotap` with `RATE`, `CHANNEL`, and `DBM_TX_POWER` fields will be generated incorrectly, due to misalignment from the `RATE` field. This PR adds the appropriate padding.