### PR TITLE
gen: Remove randomness from generated frames by default

### DIFF
--- a/src/libwifi/gen/management/action.c
+++ b/src/libwifi/gen/management/action.c
@@ -56,9 +56,6 @@ int libwifi_create_action(struct libwifi_action *action,
     memcpy(&action->frame_header.addr1, receiver, 6);
     memcpy(&action->frame_header.addr2, transmitter, 6);
     memcpy(&action->frame_header.addr3, address3, 6);
-
-    action->frame_header.seq_control.sequence_number = (rand() % 4096);
-
     action->fixed_parameters.category = category;
 
     return 0;
@@ -76,9 +73,6 @@ int libwifi_create_action_no_ack(struct libwifi_action *action,
     memcpy(&action->frame_header.addr1, receiver, 6);
     memcpy(&action->frame_header.addr2, transmitter, 6);
     memcpy(&action->frame_header.addr3, address3, 6);
-
-    action->frame_header.seq_control.sequence_number = (rand() % 4096);
-
     action->fixed_parameters.category = category;
 
     return 0;
@@ -102,6 +96,7 @@ size_t libwifi_dump_action(struct libwifi_action *action, unsigned char *buf, si
 
     memcpy(buf + offset, &action->fixed_parameters.category, sizeof(action->fixed_parameters.category));
     offset += sizeof(action->fixed_parameters.category);
+    
     memcpy(buf + offset, action->fixed_parameters.details.detail,
            action->fixed_parameters.details.detail_length);
     offset += action->fixed_parameters.details.detail_length;

--- a/src/libwifi/gen/management/assoc_request.c
+++ b/src/libwifi/gen/management/assoc_request.c
@@ -46,8 +46,6 @@ int libwifi_create_assoc_req(struct libwifi_assoc_req *assoc_req,
     memcpy(&assoc_req->frame_header.addr1, receiver, 6);
     memcpy(&assoc_req->frame_header.addr2, transmitter, 6);
     memcpy(&assoc_req->frame_header.addr3, address3, 6);
-    assoc_req->frame_header.seq_control.sequence_number = (rand() % 4096);
-
     assoc_req->fixed_parameters.capabilities_information = BYTESWAP16(LIBWIFI_DEFAULT_AP_CAPABS);
     assoc_req->fixed_parameters.listen_interval = BYTESWAP16(LIBWIFI_DEFAULT_LISTEN_INTERVAL);
 

--- a/src/libwifi/gen/management/assoc_response.c
+++ b/src/libwifi/gen/management/assoc_response.c
@@ -52,7 +52,6 @@ int libwifi_set_assoc_resp_channel(struct libwifi_assoc_resp *assoc_resp, uint8_
     }
 
     const unsigned char *chan = (const unsigned char *) &channel;
-
     ret = libwifi_quick_add_tag(&assoc_resp->tags, TAG_DS_PARAMETER, chan, 1);
 
     return ret;
@@ -74,10 +73,8 @@ int libwifi_create_assoc_resp(struct libwifi_assoc_resp *assoc_resp,
     memcpy(&assoc_resp->frame_header.addr1, receiver, 6);
     memcpy(&assoc_resp->frame_header.addr2, transmitter, 6);
     memcpy(&assoc_resp->frame_header.addr3, address3, 6);
-
     assoc_resp->fixed_parameters.capabilities_information = BYTESWAP16(LIBWIFI_DEFAULT_AP_CAPABS);
     assoc_resp->fixed_parameters.status_code = STATUS_SUCCESS;
-    assoc_resp->fixed_parameters.association_id = rand() % 4096;
 
     libwifi_set_assoc_resp_channel(assoc_resp, channel);
 

--- a/src/libwifi/gen/management/atim.c
+++ b/src/libwifi/gen/management/atim.c
@@ -29,9 +29,6 @@ int libwifi_create_atim(struct libwifi_atim *atim,
     memcpy(&atim->frame_header.addr1, transmitter, 6);
     memcpy(&atim->frame_header.addr2, receiver, 6);
     memcpy(&atim->frame_header.addr3, address3, 6);
-    atim->frame_header.frame_control.flags.power_mgmt = 1;
-    atim->frame_header.duration = (rand() % 4096);
-    atim->frame_header.seq_control.sequence_number = (rand() % 4096);
 
     return 0;
 }

--- a/src/libwifi/gen/management/authentication.c
+++ b/src/libwifi/gen/management/authentication.c
@@ -46,8 +46,6 @@ int libwifi_create_auth(struct libwifi_auth *auth,
     memcpy(&auth->frame_header.addr1, receiver, 6);
     memcpy(&auth->frame_header.addr2, transmitter, 6);
     memcpy(&auth->frame_header.addr3, address3, 6);
-    auth->frame_header.seq_control.sequence_number = (rand() % 4096);
-
     auth->fixed_parameters.algorithm_number = algorithm_number;
     auth->fixed_parameters.transaction_sequence = transaction_sequence;
     auth->fixed_parameters.status_code = status_code;

--- a/src/libwifi/gen/management/beacon.c
+++ b/src/libwifi/gen/management/beacon.c
@@ -91,8 +91,6 @@ int libwifi_create_beacon(struct libwifi_beacon *beacon,
     memcpy(&beacon->frame_header.addr1, receiver, 6);
     memcpy(&beacon->frame_header.addr2, transmitter, 6);
     memcpy(&beacon->frame_header.addr3, address3, 6);
-    beacon->frame_header.seq_control.sequence_number = (rand() % 4096);
-
     beacon->fixed_parameters.timestamp = BYTESWAP64(libwifi_get_epoch());
     beacon->fixed_parameters.beacon_interval = BYTESWAP16(LIBWIFI_DEFAULT_BEACON_INTERVAL);
     beacon->fixed_parameters.capabilities_information = BYTESWAP16(LIBWIFI_DEFAULT_AP_CAPABS);

--- a/src/libwifi/gen/management/deauthentication.c
+++ b/src/libwifi/gen/management/deauthentication.c
@@ -45,9 +45,6 @@ int libwifi_create_deauth(struct libwifi_deauth *deauth,
     memcpy(&deauth->frame_header.addr1, receiver, 6);
     memcpy(&deauth->frame_header.addr2, transmitter, 6);
     memcpy(&deauth->frame_header.addr3, address3, 6);
-
-    deauth->frame_header.seq_control.sequence_number = (rand() % 4096);
-
     memcpy(&deauth->fixed_parameters.reason_code, &reason_code, sizeof(reason_code));
 
     return 0;

--- a/src/libwifi/gen/management/disassociation.c
+++ b/src/libwifi/gen/management/disassociation.c
@@ -45,9 +45,6 @@ int libwifi_create_disassoc(struct libwifi_disassoc *disassoc,
     memcpy(&disassoc->frame_header.addr1, receiver, 6);
     memcpy(&disassoc->frame_header.addr2, transmitter, 6);
     memcpy(&disassoc->frame_header.addr3, address3, 6);
-
-    disassoc->frame_header.seq_control.sequence_number = (rand() % 4096);
-
     memcpy(&disassoc->fixed_parameters.reason_code, &reason_code, sizeof(reason_code));
 
     return 0;

--- a/src/libwifi/gen/management/probe_request.c
+++ b/src/libwifi/gen/management/probe_request.c
@@ -44,7 +44,6 @@ int libwifi_create_probe_req(struct libwifi_probe_req *probe_req,
     memcpy(&probe_req->frame_header.addr1, receiver, 6);
     memcpy(&probe_req->frame_header.addr2, transmitter, 6);
     memcpy(&probe_req->frame_header.addr3, address3, 6);
-    probe_req->frame_header.seq_control.sequence_number = (rand() % 4096);
 
     int ret = libwifi_quick_add_tag(&probe_req->tags, TAG_SSID, (const unsigned char *) ssid, strlen(ssid));
     if (ret != 0) {

--- a/src/libwifi/gen/management/probe_response.c
+++ b/src/libwifi/gen/management/probe_response.c
@@ -91,11 +91,8 @@ int libwifi_create_probe_resp(struct libwifi_probe_resp *probe_resp,
     memcpy(&probe_resp->frame_header.addr1, receiver, 6);
     memcpy(&probe_resp->frame_header.addr2, transmitter, 6);
     memcpy(&probe_resp->frame_header.addr3, address3, 6);
-
-    probe_resp->frame_header.seq_control.sequence_number = (rand() % 4096);
     probe_resp->fixed_parameters.timestamp = BYTESWAP64(libwifi_get_epoch());
-    uint16_t probe_resp_interval = 50 + (rand() % 100);
-    probe_resp->fixed_parameters.probe_resp_interval = BYTESWAP16(probe_resp_interval);
+    probe_resp->fixed_parameters.probe_resp_interval = BYTESWAP16(100);
     probe_resp->fixed_parameters.capabilities_information = BYTESWAP16(LIBWIFI_DEFAULT_AP_CAPABS);
 
     int ret = libwifi_set_probe_resp_ssid(probe_resp, ssid);

--- a/src/libwifi/gen/management/reassoc_request.c
+++ b/src/libwifi/gen/management/reassoc_request.c
@@ -48,8 +48,6 @@ int libwifi_create_reassoc_req(struct libwifi_reassoc_req *reassoc_req,
     memcpy(&reassoc_req->frame_header.addr1, receiver, 6);
     memcpy(&reassoc_req->frame_header.addr2, transmitter, 6);
     memcpy(&reassoc_req->frame_header.addr3, address3, 6);
-    reassoc_req->frame_header.seq_control.sequence_number = (rand() % 4096);
-
     reassoc_req->fixed_parameters.capabilities_information = BYTESWAP16(LIBWIFI_DEFAULT_AP_CAPABS);
     reassoc_req->fixed_parameters.listen_interval = BYTESWAP16(LIBWIFI_DEFAULT_LISTEN_INTERVAL);
     memcpy(&reassoc_req->fixed_parameters.current_ap_address, current_ap, 6);

--- a/src/libwifi/gen/management/reassoc_response.c
+++ b/src/libwifi/gen/management/reassoc_response.c
@@ -73,10 +73,8 @@ int libwifi_create_reassoc_resp(struct libwifi_reassoc_resp *reassoc_resp,
     memcpy(&reassoc_resp->frame_header.addr1, receiver, 6);
     memcpy(&reassoc_resp->frame_header.addr2, transmitter, 6);
     memcpy(&reassoc_resp->frame_header.addr3, address3, 6);
-
     reassoc_resp->fixed_parameters.capabilities_information = BYTESWAP16(LIBWIFI_DEFAULT_AP_CAPABS);
     reassoc_resp->fixed_parameters.status_code = STATUS_SUCCESS;
-    reassoc_resp->fixed_parameters.association_id = rand() % 4096;
 
     int ret = libwifi_set_reassoc_resp_channel(reassoc_resp, channel);
 

--- a/src/libwifi/gen/management/timing_ad.c
+++ b/src/libwifi/gen/management/timing_ad.c
@@ -40,7 +40,6 @@ int libwifi_create_timing_advert(struct libwifi_timing_advert *adv,
     memcpy(&adv->frame_header.addr1, destination, 6);
     memcpy(&adv->frame_header.addr2, transmitter, 6);
     memcpy(&adv->frame_header.addr3, address3, 6);
-    adv->frame_header.seq_control.sequence_number = (rand() % 4096);
 
     adv->fixed_parameters.timestamp = BYTESWAP64(libwifi_get_epoch());
     adv->fixed_parameters.measurement_pilot_interval = LIBWIFI_DEFAULT_BEACON_INTERVAL;


### PR DESCRIPTION
This was originally done to emulate what you might see from a typical airspace, but frankly, this is dumb to do in the library. The library user should be responsible for implementing these behaviours.